### PR TITLE
Hopefully fix compatibility issue with overwriting gomp openmp

### DIFF
--- a/recipe/bld-llvm-openmp.bat
+++ b/recipe/bld-llvm-openmp.bat
@@ -17,6 +17,10 @@ if errorlevel 1 exit 1
 cmake --build . --target install
 if errorlevel 1 exit 1
 
+:: delete libiomp5md.dll which is incorrectly copied over in the build
+:: del /F /Q %LIBRARY_PREFIX%\bin\libiomp5md.dll
+:: del /F /Q %LIBRARY_PREFIX%\lib\libiomp5md.dll
+
 if not exist "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include\" mkdir "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include"
 if errorlevel 1 exit 1
 

--- a/recipe/bld-llvm-openmp.bat
+++ b/recipe/bld-llvm-openmp.bat
@@ -9,16 +9,13 @@ cmake -G "Ninja" ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
     -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON ^
+    -DLIBOMP_INSTALL_ALIASES=OFF ^
     %SRC_DIR%
 
 if errorlevel 1 exit 1
 
 cmake --build . --target install
 if errorlevel 1 exit 1
-
-:: delete libiomp5md.dll which is incorrectly copied over in the build
-:: del /F /Q %LIBRARY_PREFIX%\bin\libiomp5md.dll
-:: del /F /Q %LIBRARY_PREFIX%\lib\libiomp5md.dll
 
 if not exist "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include\" mkdir "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include"
 if errorlevel 1 exit 1

--- a/recipe/build-llvm-openmp.sh
+++ b/recipe/build-llvm-openmp.sh
@@ -14,12 +14,11 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DLIBOMP_INSTALL_ALIASES=OFF \
     ..
 
 make -j${CPU_COUNT}
 make install
-
-rm -f $PREFIX/lib/libgomp$SHLIB_EXT
 
 mkdir -p $PREFIX/lib/clang/$PKG_VERSION/include
 # Standalone libomp build doesn't put omp.h in clang's default search path

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
 
 outputs:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [*] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [*] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Kraken2 apparently has a incompatibility if llvm-openmp is installed in the same env on Linux (https://github.com/DerrickWood/kraken2/issues/222#issuecomment-599280293).
On Linux Kraken2 does uses libgomp and not libomp and thus should not be affected at all by the presence of libomp.

I was reading the Homebrew libomp recipe code and saw that they the `-DLIBOMP_INSTALL_ALIASES=OFF` parameter exists to adding any libgomp aliases.
Here, I am adding the same parameter to the conda-forge recipe to correctly avoid installing anything that might interfere with libgomp.
