### PR TITLE
[rc] back to released flang version

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 fortran_compiler:
 - flang
 fortran_compiler_version:
-- '19'
+- '18'
 perl:
 - 5.32.1
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 fortran_compiler:           # [win]
   - flang                   # [win]
 fortran_compiler_version:   # [win]
-  - 19                      # [win]
+  - 18                      # [win]
 
 channel_targets:
   - conda-forge llvm_rc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/0001-link-libomp-to-compiler-rt-on-osx-arm.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: llvm-openmp


### PR DESCRIPTION
See if we can match the dev branch, which didn't need flang 19, but could handle being compiled by an already released version on main:
https://github.com/conda-forge/openmp-feedstock/blob/68a189a8a17a22d36f5a9772b8c3e2e803c3eef1/recipe/conda_build_config.yaml#L9