### PR TITLE
remove omp.h copy that's now handled by clangdev

### DIFF
--- a/recipe/install_pkg.bat
+++ b/recipe/install_pkg.bat
@@ -12,9 +12,9 @@ if %ERRORLEVEL% neq 0 exit 1
 :: paths for several likely clang versions. Since we have basically no constraints on
 :: the version of `llvm-openmp`, environments will tend to have the newest one. In turn,
 :: this means that the compiler version is (almost) always ≤ the openmp version, hence
-:: it suffices to loop until the major version here. We start from clang 16, because
-:: that is when clang switch to using only the major version in the path.
-for /L %%I in (16,1,%PKG_VERSION:~0,2%) do (
+:: it suffices to loop until the major version here. We start from clang 18, because
+:: https://github.com/conda-forge/clangdev-feedstock/pull/345 is not backported further.
+for /L %%I in (18,1,%PKG_VERSION:~0,2%) do (
     if not exist "%LIBRARY_LIB%\clang\%%I\include\" mkdir "%LIBRARY_LIB%\clang\%%I\include"
     cp %LIBRARY_INC%\omp.h %LIBRARY_LIB%\clang\%%I\include
     if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/install_pkg.bat
+++ b/recipe/install_pkg.bat
@@ -1,16 +1,24 @@
 @echo on
+setlocal enabledelayedexpansion
 
 cd openmp/build
 
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1
 
-if not exist "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include\" mkdir "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include"
-if %ERRORLEVEL% neq 0 exit 1
-
-:: Standalone libomp build doesn't put omp.h in clang's default search path
-cp %LIBRARY_PREFIX%\include\omp.h %LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include
-if %ERRORLEVEL% neq 0 exit 1
+:: we want clang to use the omp.h from this package, but stand-alone openmp doesn't
+:: put this on clang's default search path. On unix we can use a symlink, but those
+:: are not generally usable on windows. As a work-around, copy omp.h to the respective
+:: paths for several likely clang versions. Since we have basically no constraints on
+:: the version of `llvm-openmp`, environments will tend to have the newest one. In turn,
+:: this means that the compiler version is (almost) always ≤ the openmp version, hence
+:: it suffices to loop until the major version here. We start from clang 16, because
+:: that is when clang switch to using only the major version in the path.
+for /L %%I in (16,1,%PKG_VERSION:~0,2%) do (
+    if not exist "%LIBRARY_LIB%\clang\%%I\include\" mkdir "%LIBRARY_LIB%\clang\%%I\include"
+    cp %LIBRARY_INC%\omp.h %LIBRARY_LIB%\clang\%%I\include
+    if %ERRORLEVEL% neq 0 exit 1
+)
 
 :: remove fortran bits from regular llvm-openmp package
 if "%PKG_NAME%" NEQ "llvm-openmp-fortran" (

--- a/recipe/install_pkg.sh
+++ b/recipe/install_pkg.sh
@@ -7,9 +7,6 @@ cmake --install .
 
 rm -f $PREFIX/lib/libgomp$SHLIB_EXT
 
-mkdir -p $PREFIX/lib/clang/$PKG_VERSION/include
-# Standalone libomp build doesn't put omp.h in clang's default search path
-cp $PREFIX/include/omp.h $PREFIX/lib/clang/$PKG_VERSION/include
 if [[ "$target_platform" == linux-* ]]; then
   # move libarcher.so so that it doesn't interfere
   mv $PREFIX/lib/libarcher.so $PREFIX/lib/libarcher.so.bak

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "20.1.1" %}
+{% set major = version.split(".")[0]|int %}
 # check https://clang.llvm.org/docs/OpenMPSupport.html
 # occasionally to see last fully supported openmp ver.
 {% set openmp_ver = "4.5" %}
@@ -65,6 +66,11 @@ outputs:
         # headers
         - test -f $PREFIX/include/omp.h                   # [unix]
         - if not exist %LIBRARY_INC%\omp.h exit 1         # [win]
+        # clang-specific one (symlink on unix; copies on win, see install_pkg.bat)
+        - test -f $PREFIX/lib/clang/{{ major }}/include/omp.h               # [unix]
+        {% for ver in range(16, major + 1) %}
+        - if not exist %LIBRARY_LIB%\clang\{{ ver }}\include\omp.h exit 1   # [win]
+        {% endfor %}
 
         # absence of fortran bits
         - test ! -f $PREFIX/include/omp_lib.mod             # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ outputs:
         - if not exist %LIBRARY_INC%\omp.h exit 1         # [win]
         # clang-specific one (symlink on unix; copies on win, see install_pkg.bat)
         - test -f $PREFIX/lib/clang/{{ major }}/include/omp.h               # [unix]
-        {% for ver in range(16, major + 1) %}
+        {% for ver in range(18, major + 1) %}
         - if not exist %LIBRARY_LIB%\clang\{{ ver }}\include\omp.h exit 1   # [win]
         {% endfor %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/0001-link-libomp-to-compiler-rt-on-osx-arm.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,11 @@
 {% set version = "20.1.1" %}
-{% set major = version.split(".")[0]|int %}
 # check https://clang.llvm.org/docs/OpenMPSupport.html
 # occasionally to see last fully supported openmp ver.
 {% set openmp_ver = "4.5" %}
+
+# on osx we need to use cxx_compiler_version, rest can use package version
+{% set clang_major = version.split(".")[0]|int %}
+{% set clang_major = cxx_compiler_version.split(".")[0]|int %}  # [osx]
 
 package:
   name: openmp
@@ -67,8 +70,8 @@ outputs:
         - test -f $PREFIX/include/omp.h                   # [unix]
         - if not exist %LIBRARY_INC%\omp.h exit 1         # [win]
         # clang-specific one (symlink on unix; copies on win, see install_pkg.bat)
-        - test -f $PREFIX/lib/clang/{{ major }}/include/omp.h               # [unix]
-        {% for ver in range(18, major + 1) %}
+        - test -f $PREFIX/lib/clang/{{ clang_major }}/include/omp.h         # [unix]
+        {% for ver in range(18, clang_major + 1) %}
         - if not exist %LIBRARY_LIB%\clang\{{ ver }}\include\omp.h exit 1   # [win]
         {% endfor %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,9 @@
 
 # on osx we need to use cxx_compiler_version, rest can use package version
 {% set clang_major = version.split(".")[0]|int %}
+{% if cxx_compiler_version is not undefined %}
 {% set clang_major = cxx_compiler_version.split(".")[0]|int %}  # [osx]
+{% endif %}
 
 package:
   name: openmp


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/clangdev-feedstock/pull/345

Unfortunately, that approach does not apply to the windows side
https://github.com/conda-forge/openmp-feedstock/blob/faf9c161f2116f3002a655ce29b0c6b0c8090fb4/recipe/install_pkg.bat#L11-L12

because we'd really need a symlink here -- shipping it in clang risks going stale, and copying like we do currently doesn't necessarily match the clang version.

It could be done with an activation script, but for now, I think the least bad option is to copy `omp.h` to various likely clang versions. Actually, in checking up on this, I noticed that the script here was never updated once clang 16 changed the path to use the major-version only (rather than the full version) - c.f. [`clang-15`](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Fclang-15-15.0.7-default_h3a3e6c3_5.conda) and [`clang-16`](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Fclang-16-16.0.6-default_hec7ea82_14.conda) - which also makes this approach much more feasible than if we had to do it for every patch version.