### PR TITLE
[19.x] remove omp.h copy that's now handled by clangdev

### DIFF
--- a/recipe/install_pkg.bat
+++ b/recipe/install_pkg.bat
@@ -1,16 +1,24 @@
 @echo on
+setlocal enabledelayedexpansion
 
 cd openmp/build
 
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1
 
-if not exist "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include\" mkdir "%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include"
-if %ERRORLEVEL% neq 0 exit 1
-
-:: Standalone libomp build doesn't put omp.h in clang's default search path
-cp %LIBRARY_PREFIX%\include\omp.h %LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%\include
-if %ERRORLEVEL% neq 0 exit 1
+:: we want clang to use the omp.h from this package, but stand-alone openmp doesn't
+:: put this on clang's default search path. On unix we can use a symlink, but those
+:: are not generally usable on windows. As a work-around, copy omp.h to the respective
+:: paths for several likely clang versions. Since we have basically no constraints on
+:: the version of `llvm-openmp`, environments will tend to have the newest one. In turn,
+:: this means that the compiler version is (almost) always ≤ the openmp version, hence
+:: it suffices to loop until the major version here. We start from clang 18, because
+:: https://github.com/conda-forge/clangdev-feedstock/pull/345 is not backported further.
+for /L %%I in (18,1,%PKG_VERSION:~0,2%) do (
+    if not exist "%LIBRARY_LIB%\clang\%%I\include\" mkdir "%LIBRARY_LIB%\clang\%%I\include"
+    cp %LIBRARY_INC%\omp.h %LIBRARY_LIB%\clang\%%I\include
+    if %ERRORLEVEL% neq 0 exit 1
+)
 
 :: remove fortran bits from regular llvm-openmp package
 if "%PKG_NAME%" NEQ "llvm-openmp-fortran" (

--- a/recipe/install_pkg.sh
+++ b/recipe/install_pkg.sh
@@ -7,9 +7,6 @@ cmake --install .
 
 rm -f $PREFIX/lib/libgomp$SHLIB_EXT
 
-mkdir -p $PREFIX/lib/clang/$PKG_VERSION/include
-# Standalone libomp build doesn't put omp.h in clang's default search path
-cp $PREFIX/include/omp.h $PREFIX/lib/clang/$PKG_VERSION/include
 if [[ "$target_platform" == linux-* ]]; then
   # move libarcher.so so that it doesn't interfere
   mv $PREFIX/lib/libarcher.so $PREFIX/lib/libarcher.so.bak

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,12 @@
 # occasionally to see last fully supported openmp ver.
 {% set openmp_ver = "4.5" %}
 
+# on osx we need to use cxx_compiler_version, rest can use package version
+{% set clang_major = version.split(".")[0]|int %}
+{% if cxx_compiler_version is not undefined %}
+{% set clang_major = cxx_compiler_version.split(".")[0]|int %}  # [osx]
+{% endif %}
+
 package:
   name: openmp
   version: {{ version }}
@@ -19,7 +25,7 @@ source:
     - patches/0001-link-libomp-to-compiler-rt-on-osx-arm.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -65,6 +71,11 @@ outputs:
         # headers
         - test -f $PREFIX/include/omp.h                   # [unix]
         - if not exist %LIBRARY_INC%\omp.h exit 1         # [win]
+        # clang-specific one (symlink on unix; copies on win, see install_pkg.bat)
+        - test -f $PREFIX/lib/clang/{{ clang_major }}/include/omp.h         # [unix]
+        {% for ver in range(18, clang_major + 1) %}
+        - if not exist %LIBRARY_LIB%\clang\{{ ver }}\include\omp.h exit 1   # [win]
+        {% endfor %}
 
         # absence of fortran bits
         - test ! -f $PREFIX/include/omp_lib.mod             # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,9 @@ outputs:
         - openmp {{ version }}|{{ version }}.*
     test:
       requires:
-        - clangxx
+        # ensure we don't pull in too-new clang (when on maintenance branch),
+        # which breaks assumption about symlink below
+        - clangxx <={{ version }}
         - {{ compiler('cxx') }}
       files:
         - omp_hello.c


### PR DESCRIPTION
Backport #167 