### PR TITLE
[21.x] reinstate test for riscv

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   folder: llvm-project
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set openmp_ver = "4.5" %}
 
 {% set clang_major = version.split(".")[0]|int %}
-{% set clang_test_version = "19" %}
+{% set clang_test_version = "21" %}
 
 package:
   name: openmp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ outputs:
         - intel-openmp <0.0a0
     test:
       requires:
-        - clang-{{ clang_test_version }}    # [not riscv64]
+        - clang-{{ clang_test_version }}
         - {{ compiler('cxx') }}
         - ld64                      # [osx]
       files:
@@ -71,7 +71,7 @@ outputs:
         - test -f $PREFIX/include/omp.h                   # [unix]
         - if not exist %LIBRARY_INC%\omp.h exit 1         # [win]
         # clang-specific one (symlink on unix; copies on win, see install_pkg.bat)
-        - test -f $PREFIX/lib/clang/{{ clang_test_version }}/include/omp.h  # [unix and not riscv64]
+        - test -f $PREFIX/lib/clang/{{ clang_test_version }}/include/omp.h  # [unix]
         {% for ver in range(18, 21) %}
         - if not exist %LIBRARY_LIB%\clang\{{ ver }}\include\omp.h exit 1   # [win]
         {% endfor %}
@@ -92,9 +92,9 @@ outputs:
         # compilation test
         - export LNK="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"     # [unix]
         - export LNK="${LNK} -Wl,--allow-shlib-undefined"       # [linux]
-        - $PREFIX/bin/clang-{{ clang_test_version }} -v -fopenmp -I$PREFIX/include $LNK omp_hello.c -o omp_hello                    # [unix and not riscv64]
+        - $PREFIX/bin/clang-{{ clang_test_version }} -v -fopenmp -I$PREFIX/include $LNK omp_hello.c -o omp_hello                    # [unix]
         - '%LIBRARY_BIN%\clang-{{ clang_test_version }} -v -fopenmp -I%LIBRARY_INC% -L%LIBRARY_LIB% omp_hello.c -o omp_hello.exe'   # [win]
-        - ./omp_hello            # [unix and not riscv64]
+        - ./omp_hello            # [unix]
         - '%cd%\omp_hello.exe'   # [win]
 
   - name: llvm-openmp-fortran


### PR DESCRIPTION
Backport of #230 to clean up maintenance branch now that bootstrapping has been successful.